### PR TITLE
fix: Add /api prefix to admin endpoints without changing VITE_API_BAS…

### DIFF
--- a/src/web-dashboard/frontend/src/components/AnalyticsPage.tsx
+++ b/src/web-dashboard/frontend/src/components/AnalyticsPage.tsx
@@ -21,6 +21,8 @@ import {
 import MainLayout from './MainLayout';
 import toast from 'react-hot-toast';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 interface DisasterStats {
   overview: {
     total_disasters: number;
@@ -103,7 +105,7 @@ const AnalyticsPage: React.FC = () => {
       setAnalyticsData(prev => ({ ...prev, loading: true }));
 
       // Fetch disaster analytics
-      const disasterResponse = await fetch(`/api/admin/analytics/statistics?startDate=${getStartDate()}`, {
+      const disasterResponse = await fetch(`${API_BASE_URL}/api/admin/analytics/statistics?startDate=${getStartDate()}`, {
         headers: {
           'Authorization': `Bearer ${localStorage.getItem('token')}`
         }
@@ -111,7 +113,7 @@ const AnalyticsPage: React.FC = () => {
       const disasterData = await disasterResponse.json();
 
       // Fetch SOS analytics
-      const sosResponse = await fetch(`/api/admin/sos/analytics?timeRange=${timeRange}`, {
+      const sosResponse = await fetch(`${API_BASE_URL}/api/admin/sos/analytics?timeRange=${timeRange}`, {
         headers: {
           'Authorization': `Bearer ${localStorage.getItem('token')}`
         }

--- a/src/web-dashboard/frontend/src/components/NotificationBell.tsx
+++ b/src/web-dashboard/frontend/src/components/NotificationBell.tsx
@@ -4,6 +4,8 @@ import { useAuth } from '../contexts/AuthContext';
 import { authService } from '../services/authService';
 import ResponderNotifications from './ResponderNotifications';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 const NotificationBell: React.FC = () => {
   const { user } = useAuth();
   const [unreadCount, setUnreadCount] = useState(0);
@@ -15,7 +17,7 @@ const NotificationBell: React.FC = () => {
     
     try {
       const token = authService.getToken();
-      const response = await fetch('/api/responder/notifications', {
+      const response = await fetch(`${API_BASE_URL}/api/responder/notifications`, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'

--- a/src/web-dashboard/frontend/src/components/ResponderNotifications.tsx
+++ b/src/web-dashboard/frontend/src/components/ResponderNotifications.tsx
@@ -4,6 +4,8 @@ import { useAuth } from '../contexts/AuthContext';
 import { authService } from '../services/authService';
 import toast from 'react-hot-toast';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 interface Notification {
   id: string;
   type: string;
@@ -48,7 +50,7 @@ const ResponderNotifications: React.FC<NotificationPanelProps> = ({ isOpen, onCl
     
     try {
       const token = authService.getToken();
-      const response = await fetch('/api/responder/notifications', {
+      const response = await fetch(`${API_BASE_URL}/api/responder/notifications`, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
@@ -78,7 +80,7 @@ const ResponderNotifications: React.FC<NotificationPanelProps> = ({ isOpen, onCl
   const markAsRead = async (notificationId: string) => {
     try {
       const token = authService.getToken();
-      const response = await fetch(`/api/responder/notifications/${notificationId}/read`, {
+      const response = await fetch(`${API_BASE_URL}/api/responder/notifications/${notificationId}/read`, {
         method: 'PUT',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -101,7 +103,7 @@ const ResponderNotifications: React.FC<NotificationPanelProps> = ({ isOpen, onCl
   const markAllAsRead = async () => {
     try {
       const token = authService.getToken();
-      const response = await fetch('/api/responder/notifications/read-all', {
+      const response = await fetch(`${API_BASE_URL}/api/responder/notifications/read-all`, {
         method: 'PUT',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -124,7 +126,7 @@ const ResponderNotifications: React.FC<NotificationPanelProps> = ({ isOpen, onCl
   const deleteNotification = async (notificationId: string) => {
     try {
       const token = authService.getToken();
-      const response = await fetch(`/api/responder/notifications/${notificationId}`, {
+      const response = await fetch(`${API_BASE_URL}/api/responder/notifications/${notificationId}`, {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/src/web-dashboard/frontend/src/config/api.ts
+++ b/src/web-dashboard/frontend/src/config/api.ts
@@ -47,15 +47,15 @@ export const API_ENDPOINTS = {
   // Locations
   LOCATIONS: '/resources/locations',
   
-  // Map endpoints
-  MAP_REPORTS: '/map/reports',
-  MAP_HEATMAP: '/map/heatmap',
-  MAP_RESOURCE_ANALYSIS: '/map/resource-analysis',
-  MAP_DISASTERS: '/map/disasters',
+  // Map endpoints (admin/backend - need /api prefix)
+  MAP_REPORTS: '/api/map/reports',
+  MAP_HEATMAP: '/api/map/heatmap',
+  MAP_RESOURCE_ANALYSIS: '/api/map/resource-analysis',
+  MAP_DISASTERS: '/api/map/disasters',
   
-  // SOS endpoints
-  SOS_SIGNALS: '/mobile/sos-signals',
-  SOS_ANALYTICS: '/admin/sos/analytics',
+  // SOS endpoints (admin/backend - need /api prefix)
+  SOS_SIGNALS: '/api/mobile/sos-signals',
+  SOS_ANALYTICS: '/api/admin/sos/analytics',
 } as const;
 
 export default {

--- a/src/web-dashboard/frontend/src/services/analyticsService.ts
+++ b/src/web-dashboard/frontend/src/services/analyticsService.ts
@@ -1,8 +1,10 @@
 // analyticsService.ts
 // Service for National Disaster Platform Analytics API
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 export async function getDashboardStatistics(token: string) {
-  const res = await fetch('/api/admin/analytics/statistics', {
+  const res = await fetch(`${API_BASE_URL}/api/admin/analytics/statistics`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'
@@ -13,7 +15,7 @@ export async function getDashboardStatistics(token: string) {
 
 export async function getTimeline(token: string, params: Record<string, string> = {}) {
   const query = new URLSearchParams(params).toString();
-  const res = await fetch(`/api/admin/analytics/timeline${query ? '?' + query : ''}`, {
+  const res = await fetch(`${API_BASE_URL}/api/admin/analytics/timeline${query ? '?' + query : ''}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'
@@ -23,7 +25,7 @@ export async function getTimeline(token: string, params: Record<string, string> 
 }
 
 export async function getZonesOverlap(token: string) {
-  const res = await fetch('/api/admin/analytics/zones-overlap', {
+  const res = await fetch(`${API_BASE_URL}/api/admin/analytics/zones-overlap`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'
@@ -34,7 +36,7 @@ export async function getZonesOverlap(token: string) {
 
 export async function getResourceSummary(token: string, params: Record<string, string> = {}) {
   const query = new URLSearchParams(params).toString();
-  const res = await fetch(`/api/admin/analytics/resource-summary${query ? '?' + query : ''}`, {
+  const res = await fetch(`${API_BASE_URL}/api/admin/analytics/resource-summary${query ? '?' + query : ''}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'

--- a/src/web-dashboard/frontend/src/services/disasterService.ts
+++ b/src/web-dashboard/frontend/src/services/disasterService.ts
@@ -106,8 +106,10 @@ export interface DisasterFilters {
   includeArchived?: boolean;
 }
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 class DisasterService {
-  private baseURL = '/api/admin/disasters';
+  private baseURL = `${API_BASE_URL}/api/admin/disasters`;
 
   private async makeRequest(endpoint: string, options: RequestInit = {}): Promise<any> {
     const token = authService.getToken();

--- a/src/web-dashboard/frontend/src/services/donationService.ts
+++ b/src/web-dashboard/frontend/src/services/donationService.ts
@@ -3,6 +3,8 @@
 
 import { DonationStatsResponse, DonationListResponse, DonationQueryParams } from '../types/donation';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 export async function getDonationStats(token: string, startDate?: string, endDate?: string): Promise<DonationStatsResponse> {
   // Donation API disabled - return empty stats
   // Payment/donation features removed to focus on disaster response
@@ -50,7 +52,7 @@ export async function getDonations(
 }
 
 export async function getDonationById(token: string, donationId: string) {
-  const res = await fetch(`/api/donations/${donationId}`, {
+  const res = await fetch(`${API_BASE_URL}/api/donations/${donationId}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'
@@ -70,7 +72,7 @@ export async function updateDonationStatus(
   status: string,
   notes?: string
 ) {
-  const res = await fetch(`/api/donations/${donationId}/status`, {
+  const res = await fetch(`${API_BASE_URL}/api/donations/${donationId}/status`, {
     method: 'PATCH',
     headers: {
       'Authorization': `Bearer ${token}`,
@@ -87,7 +89,7 @@ export async function updateDonationStatus(
 }
 
 export async function getPaymentAnalytics(token: string, timeframe: string = '30d') {
-  const res = await fetch(`/api/donations/analytics?timeframe=${timeframe}`, {
+  const res = await fetch(`${API_BASE_URL}/api/donations/analytics?timeframe=${timeframe}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'


### PR DESCRIPTION
…E_URL

- VITE_API_BASE_URL remains as base URL without /api suffix
- Added /api prefix to all admin/backend endpoint calls
- Fixed analyticsService, disasterService, donationService
- Fixed ResponderNotifications, NotificationBell, AnalyticsPage
- Updated API_ENDPOINTS for map and mobile endpoints
- Citizen endpoints continue to work without /api prefix